### PR TITLE
Replace deprecated BS findAll with find_all + minor rune ups around

### DIFF
--- a/mkdocs_panzoom_plugin/html_page.py
+++ b/mkdocs_panzoom_plugin/html_page.py
@@ -65,14 +65,14 @@ class HTMLPage:
 
         self.config.update({"selectors": list(final_selectors)})
 
-        for selector in self.config.get("selectors",[]):
+        for selector in self.config.get("selectors", []):
             if selector.startswith("."):
-                output += self.soup.findAll(class_=selector.lstrip("."))
+                output += self.soup.find_all(class_=selector.lstrip("."))
             elif selector.startswith("#"):
                 id_element = self.soup.find(id=selector.lstrip("#"))
-                if not id_element is None:
+                if id_element is not None:
                     output.append(id_element)
             else:
-                output += self.soup.findAll(selector)
+                output += self.soup.find_all(selector)
 
         return output


### PR DESCRIPTION
Otherwise we get

    INFO    -  DeprecationWarning: Call to deprecated method findAll. (Replaced by find_all) -- Deprecated since version 4.0.0.
                 File "/home/yoh/venvs/dev3.12/lib/python3.12/site-packages/mkdocs_panzoom_plugin/html_page.py", line 70, in _find_elements
                   output += self.soup.findAll(class_=selector.lstrip("."))
                 File "/home/yoh/venvs/dev3.12/lib/python3.12/site-packages/bs4/_deprecation.py", line 56, in alias
                   warnings.warn(