### PR TITLE
Add `initial_zoom_level` configuration option

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -81,6 +81,16 @@ plugins:
       key: "ctrl" # default alt
 ```
 
+### Set Initial Zoom Level
+
+This sets the initial zoom level for all diagrams and images.
+
+```yaml
+plugins:
+  - panzoom:
+      initial_zoom_level: 1.5 # default 1.0
+```
+
 ### Exclude Pages
 
 ```yaml

--- a/mkdocs_panzoom_plugin/custom/zoompan.js
+++ b/mkdocs_panzoom_plugin/custom/zoompan.js
@@ -86,11 +86,18 @@ function activate_zoom_pan() {
 
   meta_tag = document.querySelector('meta[name="panzoom-data"]');
 
-  if (!meta_tag) return;
+  let selectors = [".panzoom-content"]; // Default selector
+  let initialZoomLevel = 1.0; // Default zoom level
 
-  const panzoomData = JSON.parse(meta_tag.content);
-  const selectors = panzoomData.selectors;
-  const initialZoomLevel = panzoomData.initial_zoom_level || 1.0;
+  if (meta_tag) {
+    try {
+      const panzoomData = JSON.parse(meta_tag.content);
+      selectors = panzoomData.selectors || selectors;
+      initialZoomLevel = panzoomData.initial_zoom_level || initialZoomLevel;
+    } catch (e) {
+      console.warn('Failed to parse panzoom data:', e);
+    }
+  }
 
   boxes.forEach((box) => {
     key = box.dataset.key;

--- a/mkdocs_panzoom_plugin/custom/zoompan.js
+++ b/mkdocs_panzoom_plugin/custom/zoompan.js
@@ -33,7 +33,7 @@ function panzoom_reset(instance) {
   if (meta_tag) {
     try {
       const data = JSON.parse(meta_tag.content);
-      initialZoom = data.initial_zoom_level || 1.0;
+      initialZoom = data.initial_zoom_level ?? 1.0;
     } catch (e) {
       console.warn('Failed to parse panzoom data:', e);
     }
@@ -93,7 +93,7 @@ function activate_zoom_pan() {
   try {
     panzoomData = JSON.parse(meta_tag.content);
     selectors = panzoomData.selectors || [];
-    initialZoomLevel = panzoomData.initial_zoom_level || 1.0;
+    initialZoomLevel = panzoomData.initial_zoom_level ?? 1.0;
   } catch (e) {
     console.warn('Failed to parse panzoom data:', e);
   }

--- a/mkdocs_panzoom_plugin/custom/zoompan.js
+++ b/mkdocs_panzoom_plugin/custom/zoompan.js
@@ -27,8 +27,20 @@ function escapeFullScreen(e, box, max, min, instance) {
 }
 
 function panzoom_reset(instance) {
+  // Get the initial zoom level from meta tag data
+  const meta_tag = document.querySelector('meta[name="panzoom-data"]');
+  let initialZoom = 1.0;
+  if (meta_tag) {
+    try {
+      const data = JSON.parse(meta_tag.content);
+      initialZoom = data.initial_zoom_level || 1.0;
+    } catch (e) {
+      console.warn('Failed to parse panzoom data:', e);
+    }
+  }
+
   instance.moveTo(0, 0);
-  instance.zoomAbs(0, 0, 1);
+  instance.zoomAbs(0, 0, initialZoom);
 }
 
 function add_buttons(box, instance) {
@@ -74,7 +86,11 @@ function activate_zoom_pan() {
 
   meta_tag = document.querySelector('meta[name="panzoom-data"]');
 
-  selectors = JSON.parse(meta_tag.content).selectors;
+  if (!meta_tag) return;
+
+  const panzoomData = JSON.parse(meta_tag.content);
+  const selectors = panzoomData.selectors;
+  const initialZoomLevel = panzoomData.initial_zoom_level || 1.0;
 
   boxes.forEach((box) => {
     key = box.dataset.key;
@@ -125,6 +141,12 @@ function activate_zoom_pan() {
         },
         zoomDoubleClickSpeed: 1,
       });
+
+      // Set the initial zoom level
+      if (initialZoomLevel !== 1.0) {
+        instance.zoomAbs(0, 0, initialZoomLevel);
+      }
+
       add_buttons(box, instance);
     }
   });

--- a/mkdocs_panzoom_plugin/custom/zoompan.js
+++ b/mkdocs_panzoom_plugin/custom/zoompan.js
@@ -86,17 +86,16 @@ function activate_zoom_pan() {
 
   meta_tag = document.querySelector('meta[name="panzoom-data"]');
 
+  let panzoomData = {};
   let selectors = [".panzoom-content"]; // Default selector
   let initialZoomLevel = 1.0; // Default zoom level
 
-  if (meta_tag) {
-    try {
-      const panzoomData = JSON.parse(meta_tag.content);
-      selectors = panzoomData.selectors || selectors;
-      initialZoomLevel = panzoomData.initial_zoom_level || initialZoomLevel;
-    } catch (e) {
-      console.warn('Failed to parse panzoom data:', e);
-    }
+  try {
+    panzoomData = JSON.parse(meta_tag.content);
+    selectors = panzoomData.selectors || [];
+    initialZoomLevel = panzoomData.initial_zoom_level || 1.0;
+  } catch (e) {
+    console.warn('Failed to parse panzoom data:', e);
   }
 
   boxes.forEach((box) => {

--- a/mkdocs_panzoom_plugin/html_page.py
+++ b/mkdocs_panzoom_plugin/html_page.py
@@ -39,7 +39,8 @@ class HTMLPage:
         meta_tag = self.soup.new_tag("meta")
         meta_tag["name"] = "panzoom-data"
         meta_tag["content"] = json.dumps({
-            "selectors": self.config.get("selectors")
+            "selectors": self.config.get("selectors"),
+            "initial_zoom_level": self.config.get("initial_zoom_level", 1.0)
             })
         theme_tag = self.soup.new_tag("meta")
         theme_tag["name"] = "panzoom-theme"
@@ -49,13 +50,13 @@ class HTMLPage:
 
     def _find_elements(self):
         output = []
-        
+
         # get final set of selectors
         included_selectors = set(self.config.get("include_selectors", [])) | set()
         excluded_selectors = set(self.config.get("exclude_selectors", [])) | set()
 
         final_selectors = self.default_selectors.difference(excluded_selectors)
-        final_selectors.update(included_selectors) 
+        final_selectors.update(included_selectors)
 
         if self.config.get("images",False):
             final_selectors.add("img")

--- a/mkdocs_panzoom_plugin/plugin.py
+++ b/mkdocs_panzoom_plugin/plugin.py
@@ -25,6 +25,7 @@ class PanZoomPlugin(BasePlugin):
         ("include_selectors", config_options.Type(list, default=[])),
         ("exclude_selectors", config_options.Type(list, default=[])),
         ("hint_location", config_options.Type(str, default="bottom")),
+        ("initial_zoom_level", config_options.Type(float, default=1.0)),
     )
 
     def on_config(self, config, **kwargs):


### PR DESCRIPTION
# Add `initial_zoom_level` configuration option

## Why

Currently, the mkdocs-panzoom plugin always initializes diagrams and images at 1.0x zoom level (100%). This can be suboptimal for Large diagrams or Accessibility.

## What

This PR adds a new configuration option `initial_zoom_level` that allows users to:

1. **Set custom initial zoom**: Configure the starting zoom level for all panzoom-enabled elements
2. **Maintain consistent UX**: The reset button now resets to the configured initial zoom level instead of hardcoded 1.0x
3. **Preserve existing behavior**: Defaults to 1.0x to maintain backward compatibility

### New Configuration Option

```yaml
plugins:
  - panzoom:
      initial_zoom_level: 1.5  # default: 1.0
```
