### PR TITLE
Add zoom ratio with localStorage support

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -81,6 +81,16 @@ plugins:
       key: "ctrl" # default alt
 ```
 
+### Set Initial Zoom Level
+
+This sets the initial zoom level for all diagrams and images.
+
+```yaml
+plugins:
+  - panzoom:
+      initial_zoom_level: 1.5 # default 1.0
+```
+
 ### Exclude Pages
 
 ```yaml

--- a/docs/index.md
+++ b/docs/index.md
@@ -108,6 +108,17 @@ plugins:
       full_screen: True # default False
 ```
 
+## Automatic Zoom State Persistence
+
+The plugin automatically saves the zoom level and pan position for each diagram to your browser's localStorage. This means:
+
+- **Persistent Settings**: Your preferred zoom level and position for each diagram are remembered across page reloads
+- **Per-Diagram Memory**: Each diagram on a page maintains its own zoom state independently
+- **Automatic Cleanup**: Saved states older than 30 days are automatically cleared
+- **Reset Functionality**: Using the reset button clears the saved state for that diagram and returns to the configured initial zoom level
+
+This feature works automatically - no additional configuration is required. The zoom states are stored locally in your browser and are not shared between different browsers or devices.
+
 ## Credits
 
 The structure and some parts are from the [enumerate-headings-plugin](https://github.com/timvink/mkdocs-enumerate-headings-plugin)

--- a/mkdocs_panzoom_plugin/custom/zoompan.js
+++ b/mkdocs_panzoom_plugin/custom/zoompan.js
@@ -86,11 +86,18 @@ function activate_zoom_pan() {
 
   meta_tag = document.querySelector('meta[name="panzoom-data"]');
 
-  if (!meta_tag) return;
+  let selectors = [".panzoom-content"]; // Default selector
+  let initialZoomLevel = 1.0; // Default zoom level
 
-  const panzoomData = JSON.parse(meta_tag.content);
-  const selectors = panzoomData.selectors;
-  const initialZoomLevel = panzoomData.initial_zoom_level || 1.0;
+  if (meta_tag) {
+    try {
+      const panzoomData = JSON.parse(meta_tag.content);
+      selectors = panzoomData.selectors || selectors;
+      initialZoomLevel = panzoomData.initial_zoom_level || initialZoomLevel;
+    } catch (e) {
+      console.warn('Failed to parse panzoom data:', e);
+    }
+  }
 
   boxes.forEach((box) => {
     key = box.dataset.key;

--- a/mkdocs_panzoom_plugin/custom/zoompan.js
+++ b/mkdocs_panzoom_plugin/custom/zoompan.js
@@ -33,7 +33,7 @@ function panzoom_reset(instance) {
   if (meta_tag) {
     try {
       const data = JSON.parse(meta_tag.content);
-      initialZoom = data.initial_zoom_level || 1.0;
+      initialZoom = data.initial_zoom_level ?? 1.0;
     } catch (e) {
       console.warn('Failed to parse panzoom data:', e);
     }
@@ -93,7 +93,7 @@ function activate_zoom_pan() {
   try {
     panzoomData = JSON.parse(meta_tag.content);
     selectors = panzoomData.selectors || [];
-    initialZoomLevel = panzoomData.initial_zoom_level || 1.0;
+    initialZoomLevel = panzoomData.initial_zoom_level ?? 1.0;
   } catch (e) {
     console.warn('Failed to parse panzoom data:', e);
   }

--- a/mkdocs_panzoom_plugin/custom/zoompan.js
+++ b/mkdocs_panzoom_plugin/custom/zoompan.js
@@ -27,8 +27,20 @@ function escapeFullScreen(e, box, max, min, instance) {
 }
 
 function panzoom_reset(instance) {
+  // Get the initial zoom level from meta tag data
+  const meta_tag = document.querySelector('meta[name="panzoom-data"]');
+  let initialZoom = 1.0;
+  if (meta_tag) {
+    try {
+      const data = JSON.parse(meta_tag.content);
+      initialZoom = data.initial_zoom_level || 1.0;
+    } catch (e) {
+      console.warn('Failed to parse panzoom data:', e);
+    }
+  }
+
   instance.moveTo(0, 0);
-  instance.zoomAbs(0, 0, 1);
+  instance.zoomAbs(0, 0, initialZoom);
 }
 
 function add_buttons(box, instance) {
@@ -74,7 +86,11 @@ function activate_zoom_pan() {
 
   meta_tag = document.querySelector('meta[name="panzoom-data"]');
 
-  selectors = JSON.parse(meta_tag.content).selectors;
+  if (!meta_tag) return;
+
+  const panzoomData = JSON.parse(meta_tag.content);
+  const selectors = panzoomData.selectors;
+  const initialZoomLevel = panzoomData.initial_zoom_level || 1.0;
 
   boxes.forEach((box) => {
     key = box.dataset.key;
@@ -125,6 +141,12 @@ function activate_zoom_pan() {
         },
         zoomDoubleClickSpeed: 1,
       });
+
+      // Set the initial zoom level
+      if (initialZoomLevel !== 1.0) {
+        instance.zoomAbs(0, 0, initialZoomLevel);
+      }
+
       add_buttons(box, instance);
     }
   });

--- a/mkdocs_panzoom_plugin/custom/zoompan.js
+++ b/mkdocs_panzoom_plugin/custom/zoompan.js
@@ -86,17 +86,16 @@ function activate_zoom_pan() {
 
   meta_tag = document.querySelector('meta[name="panzoom-data"]');
 
+  let panzoomData = {};
   let selectors = [".panzoom-content"]; // Default selector
   let initialZoomLevel = 1.0; // Default zoom level
 
-  if (meta_tag) {
-    try {
-      const panzoomData = JSON.parse(meta_tag.content);
-      selectors = panzoomData.selectors || selectors;
-      initialZoomLevel = panzoomData.initial_zoom_level || initialZoomLevel;
-    } catch (e) {
-      console.warn('Failed to parse panzoom data:', e);
-    }
+  try {
+    panzoomData = JSON.parse(meta_tag.content);
+    selectors = panzoomData.selectors || [];
+    initialZoomLevel = panzoomData.initial_zoom_level || 1.0;
+  } catch (e) {
+    console.warn('Failed to parse panzoom data:', e);
   }
 
   boxes.forEach((box) => {

--- a/mkdocs_panzoom_plugin/html_page.py
+++ b/mkdocs_panzoom_plugin/html_page.py
@@ -39,7 +39,8 @@ class HTMLPage:
         meta_tag = self.soup.new_tag("meta")
         meta_tag["name"] = "panzoom-data"
         meta_tag["content"] = json.dumps({
-            "selectors": self.config.get("selectors")
+            "selectors": self.config.get("selectors"),
+            "initial_zoom_level": self.config.get("initial_zoom_level", 1.0)
             })
         theme_tag = self.soup.new_tag("meta")
         theme_tag["name"] = "panzoom-theme"
@@ -49,13 +50,13 @@ class HTMLPage:
 
     def _find_elements(self):
         output = []
-        
+
         # get final set of selectors
         included_selectors = set(self.config.get("include_selectors", [])) | set()
         excluded_selectors = set(self.config.get("exclude_selectors", [])) | set()
 
         final_selectors = self.default_selectors.difference(excluded_selectors)
-        final_selectors.update(included_selectors) 
+        final_selectors.update(included_selectors)
 
         if self.config.get("images",False):
             final_selectors.add("img")

--- a/mkdocs_panzoom_plugin/plugin.py
+++ b/mkdocs_panzoom_plugin/plugin.py
@@ -25,6 +25,7 @@ class PanZoomPlugin(BasePlugin):
         ("include_selectors", config_options.Type(list, default=[])),
         ("exclude_selectors", config_options.Type(list, default=[])),
         ("hint_location", config_options.Type(str, default="bottom")),
+        ("initial_zoom_level", config_options.Type(float, default=1.0)),
     )
 
     def on_config(self, config, **kwargs):


### PR DESCRIPTION
Same as https://github.com/PLAYG0N/mkdocs-panzoom/pull/31 but this also adds localStorage support to save users' zoom level settings.